### PR TITLE
Fixing random world odour parsing

### DIFF
--- a/parse_bonsai_functions.py
+++ b/parse_bonsai_functions.py
@@ -119,9 +119,10 @@ def parse_rew_lms(ses_settings):
     for i in ses_settings['trial']['landmarks']:
         for j in i:
             if j['rewardSequencePosition'] > -1:
-                rew_odour.append(j['odour'])
-                rew_texture.append(j['texture'])
-                index.append(j['rewardSequencePosition'])
+                if not np.isin(j['rewardSequencePosition'], index): # avoid double counting of odours
+                    rew_odour.append(j['odour'])
+                    rew_texture.append(j['texture'])
+                    index.append(j['rewardSequencePosition'])
             else:
                 non_rew_odour.append(j['odour'])
                 non_rew_texture.append(j['texture'])
@@ -204,10 +205,10 @@ def calc_hit_fa(sess_dataframe,ses_settings):
            rewarded_all[idx] = 1
     
     #sometimes the VR drops the first release event, check for that and add a 0 as a first element if needed
-    first_release = ses_settings['trial']['landmarks'][0][0]['odour']
-    if not first_release in release_events['Events'].values[0]:
-        licked_all = np.insert(licked_all, 0, 0)
-        rewarded_all = np.insert(rewarded_all, 0, 0)
+    # first_release = ses_settings['trial']['landmarks'][0][0]['odour']
+    # if not first_release in release_events['Events'].values[0]:
+    #     licked_all = np.insert(licked_all, 0, 0)
+    #     rewarded_all = np.insert(rewarded_all, 0, 0)
 
     hit_rate = np.sum(licked_target) / len(licked_target) 
     fa_rate = np.sum(licked_distractor) / len(licked_distractor) 
@@ -271,7 +272,7 @@ def calc_transition_matrix(sess_dataframe,ses_settings):
     lick_sequence = lm_id[licked_all==1]
     num_landmarks = int(np.max(lm_id)) + 1
     ideal_sequence = lm_id[ideal_licks==1]
-
+        
     transition_matrix = np.zeros((num_landmarks, num_landmarks))
     lick_tm = np.zeros((num_landmarks, num_landmarks))
     ideal_tm = np.zeros((num_landmarks, num_landmarks))


### PR DESCRIPTION
This deals with issue #8. Odours in random world are sometimes counted twice, so the total number of targets and distractors doesn't match. 

This is now fixed by adding a condition to count the odours only once. 

Adding of a new event at the beginning of the sequence is also removed for now. This will lead to a conflict with the new updates in fix-stableworld, but can be easily resolved. 